### PR TITLE
Patcher improvements.

### DIFF
--- a/ClientPatcher/ClientPatchForm.cs
+++ b/ClientPatcher/ClientPatchForm.cs
@@ -43,8 +43,7 @@ namespace ClientPatcher
             _patcher.StartedDownload += Patcher_StartedDownload;
             _patcher.ProgressedDownload += Patcher_ProgressedDownload;
             _patcher.EndedDownload += Patcher_EndedDownload;
-
-            
+            _patcher.FailedDownload += Patcher_FailedDownload;
 
             if (ApplicationDeployment.IsNetworkDeployed)
             {
@@ -162,6 +161,10 @@ namespace ClientPatcher
         private void Patcher_EndedDownload(object sender, AsyncCompletedEventArgs e)
         {
             PbFileProgressSetValueStep(100);
+        }
+        private void Patcher_FailedDownload(object sender, InvalidOperationException e)
+        {
+            TxtLogAppendText(String.Format("Failed download: {0}\r\n", e.ToString()));
         }
 
         private void ModProfile()

--- a/ClientPatcher/ClientPatchForm.cs
+++ b/ClientPatcher/ClientPatchForm.cs
@@ -308,12 +308,10 @@ namespace ClientPatcher
 
         private void btnCacheGen_Click(object sender, EventArgs e)
         {
+            gbOptions.Visible = !gbOptions.Visible;
             TxtLogAppendText("Generating Cache of local files, this may take a while..\r\n");
             _patcher.GenerateCache();
+            TxtLogAppendText("Caching Complete!\r\n");
         }
-
-        
-
-
     }
 }

--- a/ClientPatcher/ClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher.cs
@@ -61,6 +61,7 @@ namespace ClientPatcher
     public delegate void ProgressDownloadEventHandler(object sender, DownloadProgressChangedEventArgs e);
     //Event when we Complete a Download, used to notify UI.
     public delegate void EndDownloadEventHandler(object sender, AsyncCompletedEventArgs e);
+    public delegate void FailDownloadHandler(object sender, InvalidOperationException e);
 
     #endregion
 
@@ -108,6 +109,12 @@ namespace ClientPatcher
         {
             if (EndedDownload != null)
                 EndedDownload(this, e);
+        }
+        public event FailDownloadHandler FailedDownload;
+        protected virtual void OnFailedDownload(InvalidOperationException e)
+        {
+           if (FailedDownload != null)
+              FailedDownload(this, e);
         }
         #endregion
 
@@ -324,6 +331,11 @@ Download=10016
 
         private void client_DownloadFileCompleted(object sender, AsyncCompletedEventArgs e)
         {
+            if (e.Error is InvalidOperationException)
+            {
+                OnFailedDownload((InvalidOperationException)e.Error);
+                return;
+            }
             OnEndDownload(e);
             _continueAsync = true;
         }


### PR DESCRIPTION
Commit 1
- Adds a completion message to the Verify all files option to let users know the caching has finished, and changes focus to the log output window.

Commit 2
- Add user notification if a file cannot be downloaded. Just spits out all the error information at the moment, not very readable: http://i.imgur.com/C10GPSG.png. Should cancel the whole thing, reset patcher to start and tell the user to close any open clients.

Commit 3:
- Fixed up the text on a failed file so it only displays the filename: http://i.imgur.com/zyeiP9u.png.
- Patcher will try to redownload files again once if an attempt fails.
- Patcher will close meridian.exe before patching (with a warning box) and will try to do so again if any files fail to be written. Although the message box is displayed warning the user that patching will fail if meridian.exe is open, the process is killed before the box is displayed (otherwise it can prevent the redownload attempt working).
- If a file fails twice, a fail message will be displayed at the end instead of the "Patching Complete!" message.
- Failed files also replace the hash in the downloaded patch list with the local file's hash, so future attempts to patch will still attempt to obtain the new file.
