### PR TITLE
Scan all Ogre files, remove DotNetx64 client type.

### DIFF
--- a/PatchServer/ClientScanner/ClientScanner.cs
+++ b/PatchServer/ClientScanner/ClientScanner.cs
@@ -11,8 +11,7 @@ namespace PatchListGenerator
     public enum ClientType
     {
         Classic = 0,
-        DotNetX64 = 1,
-        DotNetX86 = 2
+        DotNet = 1,
     }
     /// <summary>
     /// ClientScanner is in charge of scanning a list of files and instantiating ManagedFile objects to track them with metadata.
@@ -75,7 +74,7 @@ namespace PatchListGenerator
             Files = new List<ManagedFile>();
             foreach (string fileName in ScanFiles)
             {
-                string ext = fileName.Substring(fileName.Length - 4).ToLower();
+                string ext = Path.GetExtension(fileName).ToLower();
                 if (ScanExtensions.Contains(ext))
                 {
                     var file = new ManagedFile(fileName);

--- a/PatchServer/ClientScanner/OgreClientScanner.cs
+++ b/PatchServer/ClientScanner/OgreClientScanner.cs
@@ -13,7 +13,7 @@ namespace PatchListGenerator
        public OgreClientScanner()
            : base()
        {
-           ClientType = ClientType.DotNetX86;
+           ClientType = ClientType.DotNet;
            BasePath = "C:\\Games\\Meridian59-1.0.4.0\\";
        }
        public OgreClientScanner(string basepath)
@@ -27,8 +27,8 @@ namespace PatchListGenerator
        /// </summary>
        public override void AddExtensions()
        {
-          ScanExtensions = new List<string> { ".roo", ".dll", ".rsb", ".exe", ".bgf", ".wav", ".mp3", ".ttf", ".bsf",
-                ".font", ".ttf", ".md", ".png", ".material", ".hlsl", ".dds", ".mesh", ".xml", ".pu", ".compsoitor",
+          ScanExtensions = new List<string> { ".roo", ".dll", ".rsb", ".exe", ".bgf", ".wav", ".mp3", ".bsf",
+                ".font", ".ttf", ".md", ".png", ".material", ".hlsl", ".dds", ".mesh", ".xml", ".pu", ".compositor",
                 ".imageset", ".layout", ".looknfeel", ".scheme" };
        }
     }

--- a/PatchServer/Program.cs
+++ b/PatchServer/Program.cs
@@ -41,10 +41,7 @@ namespace PatchListGenerator
                             case "classic":
                                 clientscanner = new ClassicClientScanner(_clientPath);
                                 break;
-                            case "dotnetx86":
-                                clientscanner = new OgreClientScanner(_clientPath);
-                                break;
-                            case  "dotnetx64":
+                            case "dotnet":
                                 clientscanner = new OgreClientScanner(_clientPath);
                                 break;
                             default:
@@ -88,7 +85,7 @@ namespace PatchListGenerator
             Console.WriteLine("Not enough parameters");
             Console.WriteLine("--client=[path] - Base folder to scan for patch info");
             Console.WriteLine("--outfile=[path] - File to store patch info in");
-            Console.WriteLine("--type=[classic|DotNetX86|DotNetX64]");
+            Console.WriteLine("--type=[classic|dotnet]");
         }
     }
 }


### PR DESCRIPTION
ClientScanner now scans all ogre files.

Combined DotNetX86 and DotNetX64 ClientTypes into DotNet.
