### PR TITLE
Fix extraction of install basepath, patcher was including both the

### DIFF
--- a/ClientPatcher/ClientPatcher/ClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher/ClientPatcher.cs
@@ -287,6 +287,7 @@ namespace ClientPatcher
                 if (FileScanned != null)
                     FileScanned(this, new ScanEventArgs(patchFile.Filename)); //Tells the form to update the progress bar
                 var localFile = new ManagedFile(fullpath);
+                localFile.Basepath = patchFile.Basepath;
                 localFile.ComputeHash();
                 if (patchFile.MyHash != localFile.MyHash)
                 {

--- a/PatchServer/ClientScanner/ClientScanner.cs
+++ b/PatchServer/ClientScanner/ClientScanner.cs
@@ -78,7 +78,7 @@ namespace PatchListGenerator
                 if (ScanExtensions.Contains(ext))
                 {
                     var file = new ManagedFile(fileName);
-                    file.Basepath = fileName.Substring(BasePath.Length);
+                    file.Basepath = fileName.Substring(BasePath.Length, (fileName.Length - BasePath.Length - Path.GetFileName(fileName).Length));
                     file.ComputeHash();
                     file.FillLength();
                     Files.Add(file);


### PR DESCRIPTION
Fix extraction of install basepath, patcher was including both the basepath and the filename, which ended up in patchinfo as the basepath(download base), This was causing the patcher to try to download url/dir/filenamefilename

also fixed another path issue where the download file didn't have the basepath at all, causing the patcher to look for a download in the client root of the web directory
