### PR TITLE
Add ServerNumber variable, sort profile list by server number (default first), fixes for adding/removing profiles, code cleanup.

### DIFF
--- a/ClientPatcher/ClientPatchForm.Designer.cs
+++ b/ClientPatcher/ClientPatchForm.Designer.cs
@@ -42,6 +42,8 @@ namespace ClientPatcher
             this.btnPatch = new System.Windows.Forms.Button();
             this.label3 = new System.Windows.Forms.Label();
             this.groupProfileSettings = new System.Windows.Forms.GroupBox();
+            this.txtServerNumber = new System.Windows.Forms.TextBox();
+            this.label9 = new System.Windows.Forms.Label();
             this.label4 = new System.Windows.Forms.Label();
             this.txtFullInstallURL = new System.Windows.Forms.TextBox();
             this.btnBrowse = new System.Windows.Forms.Button();
@@ -145,6 +147,8 @@ namespace ClientPatcher
             // 
             // groupProfileSettings
             // 
+            this.groupProfileSettings.Controls.Add(this.txtServerNumber);
+            this.groupProfileSettings.Controls.Add(this.label9);
             this.groupProfileSettings.Controls.Add(this.label4);
             this.groupProfileSettings.Controls.Add(this.txtFullInstallURL);
             this.groupProfileSettings.Controls.Add(this.btnBrowse);
@@ -165,6 +169,22 @@ namespace ClientPatcher
             this.groupProfileSettings.TabIndex = 3;
             this.groupProfileSettings.TabStop = false;
             this.groupProfileSettings.Text = "Profile Settings";
+            // 
+            // txtServerNumber
+            // 
+            this.txtServerNumber.Location = new System.Drawing.Point(6, 225);
+            this.txtServerNumber.Name = "txtServerNumber";
+            this.txtServerNumber.Size = new System.Drawing.Size(86, 20);
+            this.txtServerNumber.TabIndex = 32;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(8, 209);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(78, 13);
+            this.label9.TabIndex = 31;
+            this.label9.Text = "Server Number";
             // 
             // label4
             // 
@@ -241,7 +261,7 @@ namespace ClientPatcher
             // cbDefaultServer
             // 
             this.cbDefaultServer.AutoSize = true;
-            this.cbDefaultServer.Location = new System.Drawing.Point(6, 212);
+            this.cbDefaultServer.Location = new System.Drawing.Point(6, 263);
             this.cbDefaultServer.Name = "cbDefaultServer";
             this.cbDefaultServer.Size = new System.Drawing.Size(100, 17);
             this.cbDefaultServer.TabIndex = 16;
@@ -492,6 +512,8 @@ namespace ClientPatcher
         private Label label4;
         private TextBox txtFullInstallURL;
         private Label label1;
+        private TextBox txtServerNumber;
+        private Label label9;
     }
 }
 

--- a/ClientPatcher/ClientPatchForm.cs
+++ b/ClientPatcher/ClientPatchForm.cs
@@ -80,7 +80,7 @@ namespace ClientPatcher
             }
 
             // Make sure the default is our current selection, and the data is displayed in options.
-            RefreshDdl();
+            InitDdl();
             SetPatcherProfile(ps);
         }
 
@@ -154,6 +154,7 @@ namespace ClientPatcher
                                          txtPatchInfoURL.Text, txtFullInstallURL.Text,
                                          txtServerName.Text, Convert.ToInt32(txtServerNumber.Text),
                                          cbDefaultServer.Checked, clientType);
+                    AddDdl(txtServerName.Text);
                     groupProfileSettings.Enabled = false;
                     break;
                 case ChangeType.ModProfile:
@@ -173,11 +174,8 @@ namespace ClientPatcher
             if (MessageBox.Show("Are you sure you want to delete this Profile?", "Delete Profile?",
                 MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
-                int selected = _settings.Servers.FindIndex(x => x.ServerName == ddlServer.SelectedItem.ToString());
-                _settings.Servers.RemoveAt(selected);
-                _settings.SaveSettings();
-                _settings.LoadSettings();
-                SetPatcherProfile(_settings.GetDefault());
+                _settings.RemoveProfileByName(ddlServer.SelectedItem.ToString());
+                RemoveDdl(ddlServer.SelectedItem.ToString());
             }
         }
 
@@ -309,9 +307,29 @@ namespace ClientPatcher
         }
 
         /// <summary>
+        /// Handles adding a new patcher profile to the dropdown box.
+        /// </summary>
+        private void AddDdl(string ServerName)
+        {
+            ddlServer.Items.Add(ServerName);
+            ddlServer.SelectedItem = ServerName;
+            SetPatcherProfile(_settings.FindByName(ServerName));
+        }
+
+        /// <summary>
+        /// Handles removing a patcher profile from the dropdown box.
+        /// </summary>
+        private void RemoveDdl(string ServerName)
+        {
+            ddlServer.Items.Remove(ServerName);
+            ddlServer.SelectedItem = _settings.GetDefault().ServerName;
+            SetPatcherProfile(_settings.GetDefault());
+        }
+
+        /// <summary>
         /// Refreshes the list of profiles in the UI, selects the default.
         /// </summary>
-        private void RefreshDdl()
+        private void InitDdl()
         {
             int defaultnum = _settings.GetDefault().ServerNumber;
             foreach (PatcherSettings profile in _settings.Servers)

--- a/ClientPatcher/ClientPatchForm.cs
+++ b/ClientPatcher/ClientPatchForm.cs
@@ -134,6 +134,7 @@ namespace ClientPatcher
             txtPatchInfoURL.Text = ps.PatchInfoUrl;
             txtFullInstallURL.Text = ps.FullInstallUrl;
             txtServerName.Text = ps.ServerName;
+            txtServerNumber.Text = ps.ServerNumber.ToString();
             cbDefaultServer.Checked = ps.Default;
 
             _changetype = ChangeType.ModProfile;
@@ -149,7 +150,10 @@ namespace ClientPatcher
                 case ChangeType.AddProfile:
                     ClientType clientType = ClientType.Classic;
 
-                    _settings.AddProfile(txtClientFolder.Text, txtPatchBaseURL.Text, txtPatchInfoURL.Text, txtFullInstallURL.Text, txtServerName.Text, cbDefaultServer.Checked, clientType);
+                    _settings.AddProfile(txtClientFolder.Text, txtPatchBaseURL.Text,
+                                         txtPatchInfoURL.Text, txtFullInstallURL.Text,
+                                         txtServerName.Text, Convert.ToInt32(txtServerNumber.Text),
+                                         cbDefaultServer.Checked, clientType);
                     groupProfileSettings.Enabled = false;
                     break;
                 case ChangeType.ModProfile:
@@ -166,7 +170,8 @@ namespace ClientPatcher
         /// </summary>
         private void btnRemove_Click(object sender, EventArgs e)
         {
-            if (MessageBox.Show("Are you sure you want to delete this Profile?", "Delete Profile?", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            if (MessageBox.Show("Are you sure you want to delete this Profile?", "Delete Profile?",
+                MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
             {
                 int selected = _settings.Servers.FindIndex(x => x.ServerName == ddlServer.SelectedItem.ToString());
                 _settings.Servers.RemoveAt(selected);
@@ -222,7 +227,8 @@ namespace ClientPatcher
                 return;
 
             _patcher.CurrentProfile = profile;
-            txtLog.Text += String.Format("Server {0} selected. Client located at: {1}\r\n", profile.ServerName, profile.ClientFolder);
+            txtLog.Text += String.Format("Server {0} selected. Client located at: {1}\r\n",
+                            profile.ServerName, profile.ClientFolder);
             btnPlay.Enabled = false;
 
             // Set create account text.
@@ -269,6 +275,7 @@ namespace ClientPatcher
                 txtPatchInfoURL.Text = "";
                 txtFullInstallURL.Text = "";
                 txtServerName.Text = "";
+                txtServerNumber.Text = "0";
             }
             else
             {
@@ -277,6 +284,7 @@ namespace ClientPatcher
                 txtPatchInfoURL.Text = profile.PatchInfoUrl;
                 txtFullInstallURL.Text = profile.FullInstallUrl;
                 txtServerName.Text = profile.ServerName;
+                txtServerNumber.Text = profile.ServerNumber.ToString();
                 cbDefaultServer.Checked = profile.Default;
             }
         }
@@ -292,6 +300,7 @@ namespace ClientPatcher
             _settings.Servers[selected].PatchInfoUrl = txtPatchInfoURL.Text;
             _settings.Servers[selected].FullInstallUrl = txtFullInstallURL.Text;
             _settings.Servers[selected].ServerName = txtServerName.Text;
+            _settings.Servers[selected].ServerNumber = Convert.ToInt32(txtServerNumber.Text);
             _settings.Servers[selected].Default = cbDefaultServer.Checked;
 
             _changetype = ChangeType.None;
@@ -300,7 +309,7 @@ namespace ClientPatcher
         }
 
         /// <summary>
-        /// Refreshes the profile selection to default.
+        /// Refreshes the list of profiles in the UI, selects the default.
         /// </summary>
         private void RefreshDdl()
         {
@@ -537,7 +546,7 @@ namespace ClientPatcher
         /// </summary>
         private void SetCreateAccountText(PatcherSettings ps)
         {
-            btnCreateAccount.Text = String.Format("Create Account for {0}", ps.ServerName);
+            btnCreateAccount.Text = String.Format("Create Account for {0}", ps.ServerNumber);
         }
         #endregion
 

--- a/ClientPatcher/ClientPatchForm.cs
+++ b/ClientPatcher/ClientPatchForm.cs
@@ -313,11 +313,15 @@ namespace ClientPatcher
         /// </summary>
         private void RefreshDdl()
         {
+            int defaultnum = _settings.GetDefault().ServerNumber;
             foreach (PatcherSettings profile in _settings.Servers)
             {
                 if (profile.Enabled)
                 {
-                    ddlServer.Items.Add(profile.ServerName);
+                    if (profile.ServerNumber == defaultnum)
+                        ddlServer.Items.Insert(0, profile.ServerName);
+                    else
+                        ddlServer.Items.Add(profile.ServerName);
                     if (profile.Default)
                         ddlServer.SelectedItem = profile.ServerName;
                 }

--- a/ClientPatcher/PatcherSettings/ClassicPatcherSettings.cs
+++ b/ClientPatcher/PatcherSettings/ClassicPatcherSettings.cs
@@ -8,6 +8,7 @@ namespace ClientPatcher
             : base()
         {
             ServerName = "103 - Open Meridian Official (Classic)";
+            ServerNumber = 103;
             PatchInfoUrl = "http://ww1.openmeridian.org/103/patchinfo.txt";
             FullInstallUrl = "http://ww1.openmeridian.org/103/Meridian59.Client.Classic.zip";
             ClientFolder = "C:\\Program Files\\Open Meridian\\Meridian 103";

--- a/ClientPatcher/PatcherSettings/OgrePatcherSettings.cs
+++ b/ClientPatcher/PatcherSettings/OgrePatcherSettings.cs
@@ -7,6 +7,7 @@ namespace ClientPatcher
         OgrePatcherSettings() : base()
         {
             ServerName = "103 - Open Meridian Official (Ogre)";
+            ServerNumber = 103;
             PatchInfoUrl = "http://ww1.openmeridian.org/103/ogrepatchinfo.txt";
             FullInstallUrl = "http://ww1.openmeridian.org/103/Meridian59.Ogre.Classic.zip";
             ClientFolder = "C:\\Program Files\\Open Meridian\\Meridian 103";

--- a/ClientPatcher/PatcherSettings/PatcherSettings.cs
+++ b/ClientPatcher/PatcherSettings/PatcherSettings.cs
@@ -9,6 +9,7 @@ namespace ClientPatcher
     public class PatcherSettings
     {
         public string ServerName { get; set; }     //What do we call this profile?
+        public int ServerNumber { get; set; }      // Server number.
         public string PatchInfoUrl { get; set; }   //Where is the file containing md5 hashes to compare?
         public string ClientFolder { get; set; }   //Where is the local copy of the client?
         public string PatchBaseUrl { get; set; }   //Where to download individual files?
@@ -26,9 +27,13 @@ namespace ClientPatcher
 
         }
 
-        public PatcherSettings(string servername, string patchinfourl, string clientfolder, string patchbaseurl, string fullinstallurl, bool defaultserver = false, ClientType clientType = ClientType.Classic, bool enabled = true, bool saveProfile = true, bool deleteProfile = false)
+        public PatcherSettings(string servername, int servernumber, string patchinfourl,
+                               string clientfolder, string patchbaseurl, string fullinstallurl,
+                               bool defaultserver = false, ClientType clientType = ClientType.Classic,
+                               bool enabled = true, bool saveProfile = true, bool deleteProfile = false)
         {
             ServerName = servername;
+            ServerNumber = servernumber;
             PatchInfoUrl = patchinfourl;
             ClientFolder = clientfolder;
             PatchBaseUrl = patchbaseurl;

--- a/ClientPatcher/SettingsManager.cs
+++ b/ClientPatcher/SettingsManager.cs
@@ -115,6 +115,7 @@ namespace ClientPatcher
                 Servers = GetNewSettings();
                 GrantAccess();
             }
+            Servers.Sort((x, y) => x.ServerNumber.CompareTo(y.ServerNumber));
         }
         /// <summary>
         /// JSON Serialize our PatcherSettings and write them to settings.txt

--- a/ClientPatcher/SettingsManager.cs
+++ b/ClientPatcher/SettingsManager.cs
@@ -101,6 +101,30 @@ namespace ClientPatcher
                         Servers.Add(webProfile);
                 }
             }
+
+            // Handle the transition from older profiles with null Guid to newer ones as
+            // the old profiles will be deleted. If a user is still updating the old
+            // profile, it is likely it will be the default. Search profiles and if a
+            // null Guid is found in a profile matching a newer entry, and the old
+            // profile is the default, put the old profile's path in the new profile
+            // and set that one to default.
+            foreach (PatcherSettings server in Servers)
+            {
+                if (server.Guid == null && server.Default)
+                {
+                    foreach (PatcherSettings serverMatch in Servers)
+                    {
+                        // Same PatchInfoUrl, one null Guid and one not. Use the path from
+                        // the old profile, set the new one to default.
+                        if (serverMatch.Guid != null && server.PatchInfoUrl == serverMatch.PatchInfoUrl)
+                        {
+                            serverMatch.ClientFolder = server.ClientFolder;
+                            server.Default = false;
+                            serverMatch.Default = true;
+                        }
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -231,6 +255,8 @@ namespace ClientPatcher
             localProfile.FullInstallUrl = webProfile.FullInstallUrl;
             localProfile.AccountCreationUrl = webProfile.AccountCreationUrl;
             localProfile.Enabled = webProfile.Enabled;
+            localProfile.SaveProfile = webProfile.SaveProfile;
+            localProfile.DeleteProfile = webProfile.DeleteProfile;
         }
         #endregion
 

--- a/ClientPatcher/SettingsManager.cs
+++ b/ClientPatcher/SettingsManager.cs
@@ -161,7 +161,10 @@ namespace ClientPatcher
                 ServerName = servername,
                 ServerNumber = servernumber,
                 Default = isdefault,
-                ClientType = clientType
+                ClientType = clientType,
+                Enabled = true,
+                SaveProfile = true,
+                DeleteProfile = false
             };
 
             if (isdefault)
@@ -175,6 +178,7 @@ namespace ClientPatcher
             SaveSettings();
             LoadSettings();
         }
+
         public void AddProfile(PatcherSettings newprofile)
         {
             if (newprofile.Default)
@@ -185,6 +189,13 @@ namespace ClientPatcher
                 }
             }
             Servers.Add(newprofile);
+            SaveSettings();
+            LoadSettings();
+        }
+
+        public void RemoveProfileByName(string name)
+        {
+            Servers.RemoveAt(Servers.FindIndex(x => x.ServerName == name));
             SaveSettings();
             LoadSettings();
         }

--- a/ClientPatcher/SettingsManager.cs
+++ b/ClientPatcher/SettingsManager.cs
@@ -78,6 +78,7 @@ namespace ClientPatcher
                         localProfile.PatchBaseUrl = webProfile.PatchBaseUrl;
                         localProfile.PatchInfoUrl = webProfile.PatchInfoUrl;
                         localProfile.ServerName = webProfile.ServerName;
+                        localProfile.ServerNumber = webProfile.ServerNumber;
                         localProfile.FullInstallUrl = webProfile.FullInstallUrl;
                         localProfile.AccountCreationUrl = webProfile.AccountCreationUrl;
                         localProfile.Enabled = webProfile.Enabled;
@@ -146,7 +147,9 @@ namespace ClientPatcher
         }
 
         //used when adding from form
-        public void AddProfile(string clientfolder, string patchbaseurl, string patchinfourl, string fullinstallurl, string servername, bool isdefault = false, ClientType clientType = ClientType.Classic)
+        public void AddProfile(string clientfolder, string patchbaseurl, string patchinfourl,
+                               string fullinstallurl, string servername, int servernumber,
+                               bool isdefault = false, ClientType clientType = ClientType.Classic)
         {
             var ps = new PatcherSettings
             {
@@ -155,9 +158,11 @@ namespace ClientPatcher
                 PatchInfoUrl = patchinfourl,
                 FullInstallUrl = fullinstallurl,
                 ServerName = servername,
+                ServerNumber = servernumber,
                 Default = isdefault,
                 ClientType = clientType
             };
+
             if (isdefault)
             {
                 foreach (PatcherSettings patcherSettingse in Servers.FindAll(s => s.Default))
@@ -186,6 +191,11 @@ namespace ClientPatcher
         public PatcherSettings FindByName(string name)
         {
             return Servers.Find(x => x.ServerName == name);
+        }
+
+        public PatcherSettings FindByNumber(int number)
+        {
+            return Servers.Find(x => x.ServerNumber == number);
         }
 
         /// <summary>


### PR DESCRIPTION
- Keep track of server number for each profile.
- Sorts the profiles by server number in the dropdown box, default server number first.
- Displays server number in create account button instead of profile name.
- Add regions to SettingsManager, separate some code in ClientPatchForm.
- Fixes for removing/adding profiles, and switching between modes.
