### PR TITLE
Add .NET and VS C++ redist dependency checks for Ogre client, code cleanup and misc fixes.

### DIFF
--- a/ClientPatcher/ClientPatchForm.Designer.cs
+++ b/ClientPatcher/ClientPatchForm.Designer.cs
@@ -71,7 +71,7 @@ namespace ClientPatcher
             this.btnAdd = new System.Windows.Forms.Button();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.btnCreateAccount = new System.Windows.Forms.Button();
-            this.button1 = new System.Windows.Forms.Button();
+            this.btnQuit = new System.Windows.Forms.Button();
             this.groupProfileSettings.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabBrowser.SuspendLayout();
@@ -455,16 +455,16 @@ namespace ClientPatcher
             this.btnCreateAccount.UseVisualStyleBackColor = true;
             this.btnCreateAccount.Click += new System.EventHandler(this.btnCreateAccount_Click);
             // 
-            // button1
+            // btnQuit
             // 
-            this.button1.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button1.Location = new System.Drawing.Point(12, 495);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(187, 31);
-            this.button1.TabIndex = 16;
-            this.button1.Text = "Quit";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            this.btnQuit.Font = new System.Drawing.Font("Microsoft Sans Serif", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnQuit.Location = new System.Drawing.Point(12, 495);
+            this.btnQuit.Name = "btnQuit";
+            this.btnQuit.Size = new System.Drawing.Size(187, 31);
+            this.btnQuit.TabIndex = 16;
+            this.btnQuit.Text = "Quit";
+            this.btnQuit.UseVisualStyleBackColor = true;
+            this.btnQuit.Click += new System.EventHandler(this.btnQuit_Click);
             // 
             // ClientPatchForm
             // 
@@ -473,7 +473,7 @@ namespace ClientPatcher
             this.BackgroundImage = global::ClientPatcher.Properties.Resources.Image7;
             this.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
             this.ClientSize = new System.Drawing.Size(963, 527);
-            this.Controls.Add(this.button1);
+            this.Controls.Add(this.btnQuit);
             this.Controls.Add(this.btnPlay);
             this.Controls.Add(this.btnPatch);
             this.Controls.Add(this.tabControl1);
@@ -542,7 +542,7 @@ namespace ClientPatcher
         private Label label1;
         private TextBox txtServerNumber;
         private Label label9;
-        private Button button1;
+        private Button btnQuit;
     }
 }
 

--- a/ClientPatcher/ClientPatcher/ClassicClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher/ClassicClientPatcher.cs
@@ -6,28 +6,19 @@ namespace ClientPatcher
 {
     class ClassicClientPatcher : ClientPatcher
     {
+        #region Constructors
         public ClassicClientPatcher(PatcherSettings settings)
             : base(settings)
         {
-                
         }
+        #endregion
 
+        #region Client
         public override bool IsNewClient()
         {
             return !File.Exists(CurrentProfile.ClientFolder + "\\meridian.exe");
         }
 
-        public override void GenerateCache()
-        {
-            string fullpath = CurrentProfile.ClientFolder;
-            var scanner = new ClassicClientScanner(fullpath);
-            scanner.ScannerSetup(fullpath);
-            scanner.ScanSource();
-            using (var sw = new StreamWriter(fullpath + CacheFile))
-            {
-                sw.Write(scanner.ToJson());
-            }    
-        }
         public override void Launch()
         {
             var meridian = new ProcessStartInfo
@@ -41,5 +32,28 @@ namespace ClientPatcher
 
             Process.Start(meridian);
         }
+        #endregion
+
+        #region Cache
+        public override void GenerateCache()
+        {
+            string fullpath = CurrentProfile.ClientFolder;
+            var scanner = new ClassicClientScanner(fullpath);
+            scanner.ScannerSetup(fullpath);
+            scanner.ScanSource();
+            using (var sw = new StreamWriter(fullpath + CacheFile))
+            {
+                sw.Write(scanner.ToJson());
+            }
+        }
+        #endregion
+
+        #region Dependencies
+        public override bool CheckDependencies()
+        {
+            // No dependencies.
+            return true;
+        }
+        #endregion
     }
 }

--- a/ClientPatcher/ClientPatcher/OgreClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher/OgreClientPatcher.cs
@@ -2,33 +2,28 @@
 using System.IO;
 using System.Diagnostics;
 using PatchListGenerator;
+using Microsoft.Win32;
 
 namespace ClientPatcher
 {
     class OgreClientPatcher : ClientPatcher
     {
+        #region Constructors
+        private string NETDownloadUri = "https://www.microsoft.com/en-US/download/details.aspx?id=48130";
+        private string NETDownloadMsg = "The Ogre client requires .NET version 4.5.1 or greater, please install this to continue.";
+
         public OgreClientPatcher(PatcherSettings settings)
             : base(settings)
         {
-                
         }
+        #endregion
 
+        #region Client
         public override bool IsNewClient()
         {
             return !File.Exists(CurrentProfile.ClientFolder + "\\x86\\Meridian59.Ogre.Client.exe");
         }
 
-        public override void GenerateCache()
-        {
-            string fullpath = CurrentProfile.ClientFolder;
-            var scanner = new OgreClientScanner(fullpath);
-            scanner.ScannerSetup(fullpath);
-            scanner.ScanSource();
-            using (var sw = new StreamWriter(fullpath + CacheFile))
-            {
-                sw.Write(scanner.ToJson());
-            }    
-        }
         public override void Launch()
         {
             var meridian = new ProcessStartInfo
@@ -42,5 +37,41 @@ namespace ClientPatcher
 
             Process.Start(meridian);
         }
+        #endregion
+
+        #region Cache
+        public override void GenerateCache()
+        {
+            string fullpath = CurrentProfile.ClientFolder;
+            var scanner = new OgreClientScanner(fullpath);
+            scanner.ScannerSetup(fullpath);
+            scanner.ScanSource();
+            using (var sw = new StreamWriter(fullpath + CacheFile))
+            {
+                sw.Write(scanner.ToJson());
+            }    
+        }
+        #endregion
+
+        #region Dependencies
+        public override bool CheckDependencies()
+        {
+            using (RegistryKey ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine,
+                RegistryView.Registry32).OpenSubKey("SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\"))
+            {
+                int releaseKey = Convert.ToInt32(ndpKey.GetValue("Release"));
+                // If a user has a .NET version lower than 4.5, send them to download it.
+                // Release key value from https://msdn.microsoft.com/en-us/library/hh925568%28v=vs.110%29.aspx#net_d
+                if (releaseKey < 378675)
+                {
+                    OnFailedDependency(new FailedDependencyEventArgs(NETDownloadUri, NETDownloadMsg));
+
+                    return false;
+                }
+
+                return true;
+            }
+        }
+        #endregion
     }
 }

--- a/ClientPatcher/ClientPatcher/OgreClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher/OgreClientPatcher.cs
@@ -9,8 +9,13 @@ namespace ClientPatcher
     class OgreClientPatcher : ClientPatcher
     {
         #region Constructors
-        private string NETDownloadUri = "https://www.microsoft.com/en-US/download/details.aspx?id=48130";
-        private string NETDownloadMsg = "The Ogre client requires .NET version 4.5.1 or greater, please install this to continue.";
+        private const string NETRegistryKey = "SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\";
+        private const string NETDownloadUri = "https://www.microsoft.com/en-US/download/details.aspx?id=48130";
+        private const string NETDownloadMsg = "The Ogre client requires .NET version 4.5.1 or greater, please install this to continue.";
+        private const string VSRedistx86Key = "SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\12.0\\VC\\Runtimes\\x86";
+        private const string VSRedistx64Key = "SOFTWARE\\Wow6432Node\\Microsoft\\VisualStudio\\12.0\\VC\\Runtimes\\x64";
+        private const string VSRedistDlUri = "https://www.microsoft.com/en-US/download/details.aspx?id=40784";
+        private const string VSRedistDlMsg = "The Ogre client requires the VS 2013 C++ redistributable, please install this to continue.";
 
         public OgreClientPatcher(PatcherSettings settings)
             : base(settings)
@@ -57,7 +62,7 @@ namespace ClientPatcher
         public override bool CheckDependencies()
         {
             using (RegistryKey ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine,
-                RegistryView.Registry32).OpenSubKey("SOFTWARE\\Microsoft\\NET Framework Setup\\NDP\\v4\\Full\\"))
+                RegistryView.Registry32).OpenSubKey(NETRegistryKey))
             {
                 int releaseKey = Convert.ToInt32(ndpKey.GetValue("Release"));
                 // If a user has a .NET version lower than 4.5, send them to download it.
@@ -68,9 +73,29 @@ namespace ClientPatcher
 
                     return false;
                 }
-
-                return true;
             }
+
+            string VSRedistKey;
+            if (Environment.Is64BitOperatingSystem)
+                VSRedistKey = VSRedistx64Key;
+            else
+                VSRedistKey = VSRedistx86Key;
+
+            using (RegistryKey ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine,
+                RegistryView.Registry32).OpenSubKey(VSRedistKey))
+            {
+                // null key converts to 0.
+                int releaseKey = Convert.ToInt32(ndpKey.GetValue("Installed"));
+                // If a user does not have VS 2013 C++ redist installed, download them.
+                if (releaseKey == 0)
+                {
+                    OnFailedDependency(new FailedDependencyEventArgs(VSRedistDlUri, VSRedistDlMsg));
+
+                    return false;
+                }
+            }
+
+            return true;
         }
         #endregion
     }

--- a/ClientPatcher/SettingsManager.cs
+++ b/ClientPatcher/SettingsManager.cs
@@ -248,6 +248,7 @@ namespace ClientPatcher
         /// </summary>
         private void UpdateProfile(PatcherSettings localProfile, PatcherSettings webProfile)
         {
+            localProfile.ClientType = webProfile.ClientType;
             localProfile.PatchBaseUrl = webProfile.PatchBaseUrl;
             localProfile.PatchInfoUrl = webProfile.PatchInfoUrl;
             localProfile.ServerName = webProfile.ServerName;


### PR DESCRIPTION
This should be ready to merge unless anyone can find something wrong. I don't think we need the DirectX End-User Runtime check as the only people likely missing this are on XP and won't be able to install the .NET framework afaik.
- Added ClientType variable to the list of vars updated from the web profiles.
- Added a dependency check for .NET version 4.5.1 or higher when downloading Ogre client. If the user has a lower version, the download is stopped and the user is directed to download .NET in the patcher's browser window.
- Added a dependency check for the VS 2013 C++ redistributables when downloading Ogre client. User is redirected to download them if missing.
- Event handlers are now removed from a ClientPatcher object when a new one is instantiated. Not doing this prevents the old one from being deleted, and all event handlers will be called if the event occurs.
- Moved more code into regions for ease of editing.
- Renamed button1 to btnQuit.
- Added a GetClientPatcher() function to ClientPatchForm.cs which uses the ClientType of the passed PatcherSettings to decide which ClientPatcher object type to use. Adds/removes event handlers.
