### PR TITLE
Add version number to patchinfo/ManagedFile, shrink "Create account" button text.

### DIFF
--- a/ClientPatcher/ClientPatchForm.Designer.cs
+++ b/ClientPatcher/ClientPatchForm.Designer.cs
@@ -446,7 +446,7 @@ namespace ClientPatcher
             // 
             // btnCreateAccount
             // 
-            this.btnCreateAccount.Font = new System.Drawing.Font("Heidelberg-Normal", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnCreateAccount.Font = new System.Drawing.Font("Heidelberg-Normal", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.btnCreateAccount.Location = new System.Drawing.Point(27, 535);
             this.btnCreateAccount.Name = "btnCreateAccount";
             this.btnCreateAccount.Size = new System.Drawing.Size(187, 31);

--- a/ClientPatcher/ClientPatchForm.cs
+++ b/ClientPatcher/ClientPatchForm.cs
@@ -442,14 +442,20 @@ namespace ClientPatcher
                     TxtLogAppendText("Using local cache....\r\n");
                     showFileNames = false;
                     _patcher.LoadCache();
-                    _patcher.CompareCache();
-                    PostScan();
+                    if (_patcher.CompareCache())
+                    {
+                        PostScan();
+                    }
+                    else
+                    {
+                        TxtLogAppendText("Local cache invalid!\r\n");
+                        ScanLocalFiles();
+                    }
                 }
                 else
                 {
-                    TxtLogAppendText("Scanning local files...\r\n");
                     showFileNames = true;
-                    bgScanWorker.RunWorkerAsync(_patcher);
+                    ScanLocalFiles();
                 }
             }
             else
@@ -457,6 +463,15 @@ namespace ClientPatcher
                 txtLog.AppendText("ERROR: Unable to download Patch Information! Please try again later or raise an issue at openmeridian.org/forums/\r\n");
                 btnPatch.Enabled = true;
             }
+        }
+
+        /// <summary>
+        /// Scans local files, called if not using local cache.
+        /// </summary>
+        private void ScanLocalFiles()
+        {
+            TxtLogAppendText("Scanning local files...\r\n");
+            bgScanWorker.RunWorkerAsync(_patcher);
         }
 
         private void PostScan()

--- a/ClientPatcher/ClientPatchForm.cs
+++ b/ClientPatcher/ClientPatchForm.cs
@@ -462,6 +462,9 @@ namespace ClientPatcher
             {
                 txtLog.AppendText("ERROR: Unable to download Patch Information! Please try again later or raise an issue at openmeridian.org/forums/\r\n");
                 btnPatch.Enabled = true;
+                pbProgress.Visible = false;
+                pbFileProgress.Visible = false;
+                ddlServer.Enabled = true;
             }
         }
 

--- a/ClientPatcher/ClientPatcher/ClassicClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher/ClassicClientPatcher.cs
@@ -16,7 +16,7 @@ namespace ClientPatcher
         #region Client
         public override bool IsNewClient()
         {
-            return !File.Exists(CurrentProfile.ClientFolder + "\\meridian.exe");
+            return !Directory.Exists(CurrentProfile.ClientFolder + "\\resource\\");
         }
 
         public override void Launch()

--- a/ClientPatcher/ClientPatcher/ClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher/ClientPatcher.cs
@@ -357,8 +357,8 @@ namespace ClientPatcher
         {
             if (IsNewClient())
                 CreateNewClient();
-
-            CompareFiles();
+            else
+                CompareFiles();
         }
 
         private void CreateFolderStructure()
@@ -376,7 +376,6 @@ namespace ClientPatcher
             if (file != null)
             {
                 DownloadOneFileAsync(file);
-
 
                 while (!_continueAsync)
                 {

--- a/ClientPatcher/ClientPatcher/OgreClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher/OgreClientPatcher.cs
@@ -26,7 +26,7 @@ namespace ClientPatcher
         #region Client
         public override bool IsNewClient()
         {
-            return !File.Exists(CurrentProfile.ClientFolder + "\\x86\\Meridian59.Ogre.Client.exe");
+            return !Directory.Exists(CurrentProfile.ClientFolder + "\\x86\\");
         }
 
         public override void Launch()

--- a/PatchServer/ClientScanner/ClassicClientScanner.cs
+++ b/PatchServer/ClientScanner/ClassicClientScanner.cs
@@ -6,21 +6,27 @@ namespace PatchListGenerator
 {
     public class ClassicClientScanner : ClientScanner
     {
+        #region Properties
         public ClientType ClientType { get; set; }
         public override String BasePath { get; set; }
+        #endregion
+
+        #region Constructors
         public ClassicClientScanner()
             : base()
         {
             ClientType = ClientType.Classic;
             BasePath = "C:\\Games\\meridian_112\\";
         }
+
         public ClassicClientScanner(string basepath)
             : base(basepath)
         {
             BasePath = basepath;
         }
+        #endregion
 
-
+        #region File Handling/Searching
         /// <summary>
         /// Adds the extensions of files to scan for when using the Classic/Legacy Meridian Client
         /// </summary>
@@ -28,6 +34,7 @@ namespace PatchListGenerator
         {
             ScanExtensions = new List<string> { ".roo", ".dll", ".rsb", ".exe", ".bgf", ".wav", ".mp3", ".ttf", ".bsf" };
         }
+
         /// <summary>
         /// Adds the special files to scan for when using the Classic/Legacy Meridian Client
         /// </summary>
@@ -38,5 +45,6 @@ namespace PatchListGenerator
             if (File.Exists(BasePath + "latest.zip"))
                 SpecialFiles.Add(new ManagedFile(BasePath + "latest.zip", false));
         }
+        #endregion
     }
 }

--- a/PatchServer/ClientScanner/ClientScanner.cs
+++ b/PatchServer/ClientScanner/ClientScanner.cs
@@ -18,12 +18,15 @@ namespace PatchListGenerator
     /// </summary>
     public class ClientScanner
     {
+        #region Properties
         private List<string> ScanFiles { get; set; }
         public List<string> ScanExtensions { get; set; }
         public List<ManagedFile> Files { get; set; }
         public List<ManagedFile> SpecialFiles { get; set; }
         public virtual string BasePath { get; set; }
-        
+        #endregion
+
+        #region Constructors
         public ClientScanner()
         {
         }
@@ -32,16 +35,12 @@ namespace PatchListGenerator
         {
             BasePath = basepath;
         }
+        #endregion
 
+        #region File Handling/Searching
         public virtual void AddExtensions() { }
         public virtual void AddSpecialFiles() { }
-        public void ScannerSetup(string basepath)
-        {
-            AddExtensions();
-            AddSpecialFiles();
-            ScanFiles = new List<string>();
-            ScanFiles.AddRange(DirSearch(basepath));
-        }
+
         /// <summary>
         /// Recursive function to get all files in a directory and sub-directories
         /// </summary>
@@ -68,9 +67,20 @@ namespace PatchListGenerator
 
             return files;
         }
+        #endregion
+
+        #region Scanning
+        public void ScannerSetup(string basepath)
+        {
+            AddExtensions();
+            AddSpecialFiles();
+            ScanFiles = new List<string>();
+            ScanFiles.AddRange(DirSearch(basepath));
+        }
 
         /// <summary>
-        /// Scans each file in the ScanFiles property of the ClientScanner Class, ManagedFile objects are added to the Files property of the ClientScanner Class
+        /// Scans each file in the ScanFiles property of the ClientScanner Class,
+        /// ManagedFile objects are added to the Files property of the ClientScanner Class
         /// </summary>
         public void ScanSource()
         {
@@ -84,23 +94,28 @@ namespace PatchListGenerator
                     file.Basepath = fileName.Substring(BasePath.Length, (fileName.Length - BasePath.Length - Path.GetFileName(fileName).Length));
                     file.ComputeHash();
                     file.FillLength();
+                    file.Version = ManagedFileVersion.VersionNum;
                     Files.Add(file);
                 }
             }
         }
+        #endregion
 
+        #region JSON
         public string ToJson()
         {
             if (SpecialFiles != null)
                 Files.AddRange(SpecialFiles);
             return JsonConvert.SerializeObject(Files, Formatting.Indented);
         }
+        #endregion
 
+        #region Util
         public void Report()
         {
             foreach (ManagedFile file in Files)
                 Console.WriteLine(file.ToString());
         }
-
+        #endregion
     }
 }

--- a/PatchServer/ClientScanner/OgreClientScanner.cs
+++ b/PatchServer/ClientScanner/OgreClientScanner.cs
@@ -6,39 +6,47 @@ namespace PatchListGenerator
 {
     public class OgreClientScanner : ClientScanner
     {
-       public ClientType ClientType { get; set; }
-       public override String BasePath { get; set; }
+        #region Properties
+        public ClientType ClientType { get; set; }
+        public override String BasePath { get; set; }
+        #endregion
 
-       public OgreClientScanner()
-           : base()
-       {
-           ClientType = ClientType.DotNet;
-           BasePath = "C:\\Games\\Meridian59-1.0.4.0\\";
-       }
-       public OgreClientScanner(string basepath)
-            : base(basepath)
+        #region Constructors
+        public OgreClientScanner()
+            : base()
         {
-            BasePath = basepath;
+            ClientType = ClientType.DotNet;
+            BasePath = "C:\\Games\\Meridian59-1.0.4.0\\";
         }
 
-       /// <summary>
-       /// Adds the extensions of files to scan for when using Ogre3d/.NET Meridian Client
-       /// </summary>
-       public override void AddExtensions()
-       {
-          ScanExtensions = new List<string> { ".roo", ".dll", ".rsb", ".exe", ".bgf", ".wav", ".mp3", ".bsf",
+        public OgreClientScanner(string basepath)
+             : base(basepath)
+        {
+             BasePath = basepath;
+        }
+        #endregion
+
+        #region File Handling/Searching
+        /// <summary>
+        /// Adds the extensions of files to scan for when using Ogre3d/.NET Meridian Client
+        /// </summary>
+        public override void AddExtensions()
+        {
+           ScanExtensions = new List<string> { ".roo", ".dll", ".rsb", ".exe", ".bgf", ".wav", ".mp3", ".bsf",
                 ".font", ".ttf", ".md", ".png", ".material", ".hlsl", ".dds", ".mesh", ".xml", ".pu", ".compositor",
                 ".imageset", ".layout", ".looknfeel", ".scheme" };
-       }
-       /// <summary>
-       /// Adds the special files to scan for when using Ogre3d/.NET Meridian Client
-       /// </summary>
-       public override void AddSpecialFiles()
-       {
-           SpecialFiles = new List<ManagedFile>();
+        }
 
-           if (File.Exists(BasePath + "\\" + "latest.zip"))
-             SpecialFiles.Add(new ManagedFile(BasePath + "\\" + "latest.zip", false));
-       }
+        /// <summary>
+        /// Adds the special files to scan for when using Ogre3d/.NET Meridian Client
+        /// </summary>
+        public override void AddSpecialFiles()
+        {
+            SpecialFiles = new List<ManagedFile>();
+
+            if (File.Exists(BasePath + "\\" + "latest.zip"))
+                SpecialFiles.Add(new ManagedFile(BasePath + "\\" + "latest.zip", false));
+        }
+        #endregion
     }
 }

--- a/PatchServer/ManagedFile.cs
+++ b/PatchServer/ManagedFile.cs
@@ -57,14 +57,15 @@ namespace PatchListGenerator
         #endregion
 
         /// <summary>
-        /// Pulls out the file path and name, adds Beasepath(relative) metadata
+        /// Pulls out the file path and name, adds Basepath(relative) metadata
         /// </summary>
         public void ParseFilePath()
         {
             Path = System.IO.Path.GetDirectoryName(Filepath);
             Filename = System.IO.Path.GetFileName(Filepath);
-            if (Filepath.Contains("resource"))
-                Basepath = "\\resource\\";
+            // I don't think this part is needed any longer.
+            //if (Filepath.Contains("resource"))
+              //  Basepath = "\\resource\\";
         }
 
         /// <summary>

--- a/PatchServer/ManagedFile.cs
+++ b/PatchServer/ManagedFile.cs
@@ -7,7 +7,18 @@ using Newtonsoft.Json;
 namespace PatchListGenerator
 {
     /// <summary>
-    /// ManagedFiles are files that can compute their own hash, parse their own path, and read other metadata from themselves, such as size.
+    /// Increment version whenever the format of ManagedFile is changed.
+    /// Necessary so that format changes don't require all users to download
+    /// the entire client again due to having an incorrect cache.txt.
+    /// </summary>
+    public enum ManagedFileVersion
+    {
+        VersionNum = 1
+    }
+
+    /// <summary>
+    /// ManagedFiles are files that can compute their own hash, parse their own path,
+    /// and read other metadata from themselves, such as size.
     /// </summary>
     public class ManagedFile
     {
@@ -21,7 +32,9 @@ namespace PatchListGenerator
         public string MyHash { get; set; } //what is the hash of this file
         public long Length;
         public bool Download = true;
+        public ManagedFileVersion Version;
 
+        #region Constructors
         public ManagedFile()
         {
         }
@@ -36,10 +49,13 @@ namespace PatchListGenerator
         {
             Filepath = filepath;
             Download = autoDownload;
+            Version = ManagedFileVersion.VersionNum;
             ParseFilePath();
             ComputeHash();
             FillLength();
         }
+        #endregion
+
         /// <summary>
         /// Pulls out the file path and name, adds Beasepath(relative) metadata
         /// </summary>
@@ -50,6 +66,7 @@ namespace PatchListGenerator
             if (Filepath.Contains("resource"))
                 Basepath = "\\resource\\";
         }
+
         /// <summary>
         /// We compute an MD5 hash of ourselves using the firs 64 bytes of the file and metadata and save it in the MyHash property
         /// </summary>
@@ -82,6 +99,7 @@ namespace PatchListGenerator
 
             MyHash = ByteArrayToString(md5.ComputeHash(hashableBytes));
         }
+
         /// <summary>
         /// Utility function
         /// </summary>
@@ -102,6 +120,7 @@ namespace PatchListGenerator
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
+
         /// <summary>
         /// Fill file-length metadata
         /// </summary>


### PR DESCRIPTION
##### Commit 1
- Added a version number to the ManagedFile class to allow the patcher to invalidate a user's cache.txt if the contents were generated with an older version of the patcher. Due to the improvements to the hashing function this change is required to prevent all users having to redownload every file.
- Fixed JSON indenting on locally generated cache.
- Moved more code into regions for ease of reading/editing (think I got it all now).
##### Commit 2
- Shrank "Create account" button text from 14.25 to 12 so the text fits on the button (didn't find a way to resize this text automatically).
- Removed the basepath change from \ to \resource\; I don't think this is needed any longer.
##### Commit 3
- Now checks for the presence of directories (\x86 for ogre and \resource for classic) to determine whether the zip should be downloaded.
- Don't run CompareFiles() if downloading the zip.
- If the patch cannot be downloaded, the progress bar is removed and the dropdown selection is reenabled.
