### PR TITLE
Increase MD5 bytes to 1024, also compare length. Increment file version number.

### DIFF
--- a/ClientPatcher/ClientPatcher/ClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher/ClientPatcher.cs
@@ -464,7 +464,8 @@ namespace ClientPatcher
                         return false;
                     }
 
-                    if (patchFile.MyHash != currentFile.MyHash)
+                    if (patchFile.MyHash != currentFile.MyHash
+                        || patchFile.Length != currentFile.Length)
                     {
                         currentFile.Length = patchFile.Length;
                         downloadFiles.Add(currentFile);
@@ -508,7 +509,8 @@ namespace ClientPatcher
                 var localFile = new ManagedFile(fullpath);
                 localFile.Basepath = patchFile.Basepath;
                 localFile.ComputeHash();
-                if (patchFile.MyHash != localFile.MyHash)
+                if (patchFile.MyHash != localFile.MyHash
+                    || patchFile.Length != localFile.Length)
                 {
                     downloadFiles.Add(localFile);
                     localFile.Length = patchFile.Length;

--- a/PatchServer/ManagedFile.cs
+++ b/PatchServer/ManagedFile.cs
@@ -13,7 +13,7 @@ namespace PatchListGenerator
     /// </summary>
     public enum ManagedFileVersion
     {
-        VersionNum = 1
+        VersionNum = 2
     }
 
     /// <summary>
@@ -69,11 +69,13 @@ namespace PatchListGenerator
         }
 
         /// <summary>
-        /// We compute an MD5 hash of ourselves using the firs 64 bytes of the file and metadata and save it in the MyHash property
+        /// We compute an MD5 hash of ourselves using the first 1024 bytes of
+        /// the file and metadata and save it in the MyHash property
         /// </summary>
         public void ComputeHash()
         {
-            //We're going to read the first 64 bytes or so of the file, salt it with the filename, and coompute a MD5 hash.
+            // We're going to read the first 1024 bytes or so of the file,
+            // salt it with the filename, and coompute a MD5 hash.
 
             MD5 md5 = MD5.Create();
             if (!File.Exists(Filepath))
@@ -83,8 +85,10 @@ namespace PatchListGenerator
             }
 
             FileStream stream = File.OpenRead(Filepath);
-            long numBytesToRead = 64;
-            if (stream.Length < 64) //Make sure we dont read past the end of a file smaller than 64 bytes
+            long numBytesToRead = 1024;
+
+            // Make sure we dont read past the end of a file smaller than 1024 bytes.
+            if (stream.Length < 1024)
             {
                 numBytesToRead = stream.Length;
             }


### PR DESCRIPTION
Increased number of file bytes in MD5 hash from 64 to 1024 (catches dll
and exe).

Compare patch and local file length when adding files.

Increment ManagedFile version number as hashing scheme has changed.
