### PR TITLE
Add length for new ManagedFiles.

### DIFF
--- a/PatchServer/ManagedFile.cs
+++ b/PatchServer/ManagedFile.cs
@@ -43,6 +43,7 @@ namespace PatchListGenerator
         {
             Filepath = filepath;
             ParseFilePath();
+            FillLength();
         }
 
         public ManagedFile(string filepath,bool autoDownload)


### PR DESCRIPTION
If this isn't added the old files don't match the length in the ones in the downloaded patchinfo.
