### PR TITLE
Add .ogg audio files to scanner.

### DIFF
--- a/PatchServer/ClientScanner/ClassicClientScanner.cs
+++ b/PatchServer/ClientScanner/ClassicClientScanner.cs
@@ -32,7 +32,7 @@ namespace PatchListGenerator
         /// </summary>
         public override void AddExtensions()
         {
-            ScanExtensions = new List<string> { ".roo", ".dll", ".rsb", ".exe", ".bgf", ".wav", ".mp3", ".ttf", ".bsf" };
+            ScanExtensions = new List<string> { ".roo", ".dll", ".rsb", ".exe", ".bgf", ".wav", ".mp3", ".ttf", ".bsf", ".ogg" };
         }
 
         /// <summary>

--- a/PatchServer/ClientScanner/OgreClientScanner.cs
+++ b/PatchServer/ClientScanner/OgreClientScanner.cs
@@ -34,7 +34,7 @@ namespace PatchListGenerator
         {
            ScanExtensions = new List<string> { ".roo", ".dll", ".rsb", ".exe", ".bgf", ".wav", ".mp3", ".bsf",
                 ".font", ".ttf", ".md", ".png", ".material", ".hlsl", ".dds", ".mesh", ".xml", ".pu", ".compositor",
-                ".imageset", ".layout", ".looknfeel", ".scheme" };
+                ".imageset", ".layout", ".looknfeel", ".scheme", ".ogg" };
         }
 
         /// <summary>


### PR DESCRIPTION
Using ogg format instead of mp3 would lower the size of the audio files from 202mb to 124mb with no difference in sound quality.
