### PR TITLE
Need to run CompareFiles() if we don't get the zip file.

### DIFF
--- a/ClientPatcher/ClientPatcher/ClientPatcher.cs
+++ b/ClientPatcher/ClientPatcher/ClientPatcher.cs
@@ -395,7 +395,12 @@ namespace ClientPatcher
 
                     if (File.Exists(CurrentProfile.ClientFolder + file.Basepath + file.Filename))
                         File.Delete(CurrentProfile.ClientFolder + file.Basepath + file.Filename);
+                    CompareFiles();
                 }
+            }
+            else
+            {
+                CompareFiles();
             }
         }
         #endregion


### PR DESCRIPTION
If the zip download is failing for any reason, the patcher should run CompareFiles() to determine what files it does have, and if it should patch again using the unzipped client.

I haven't stepped through the code to see exactly why the 105 latest.zip is failing but I suspect it's due to the different file path on my settings.php entry (C:\Program Files\Open Meridian\Meridian 105\ vs C:\Program Files\Open Meridian\Meridian 104) however the extra backslashes need to be there else the files are dumped in Open Meridian\. Would it matter that my patch files are hosted on IIS as opposed to a linux server?
